### PR TITLE
[AH-7] SSAFY 금융 API 연동

### DIFF
--- a/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/AccountAuthClient.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/AccountAuthClient.java
@@ -1,0 +1,40 @@
+package com.alddeul.solsolhanhankki.account.auth.client;
+
+import com.alddeul.solsolhanhankki.account.auth.client.dto.CheckAuthCodeRequest;
+import com.alddeul.solsolhanhankki.account.auth.client.dto.CheckAuthCodeResponse;
+import com.alddeul.solsolhanhankki.account.auth.client.dto.OneCentTransferRequest;
+import com.alddeul.solsolhanhankki.account.auth.client.dto.OneCentTransferResponse;
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.alddeul.solsolhanhankki.global.client.util.WebClientHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountAuthClient {
+    private final WebClientHelper webClientHelper;
+
+    @Value("${financial.api.base-url}")
+    private String url;
+
+    @Value("${financial.api.key}")
+    private String appKey;
+
+    @Value("${financial.api.name}")
+    private String appName;
+
+    public OneCentTransferResponse openAccountAuth(String userKey, String accountNo) {
+        String apiName = "openAccountAuth";
+        RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
+        OneCentTransferRequest request = OneCentTransferRequest.of(header, accountNo, appName);
+        return webClientHelper.postRequest(url + "/api/v1/edu/accountAuth/openAccountAuth", request, OneCentTransferResponse.class);
+    }
+
+    public CheckAuthCodeResponse checkAuthCode(String userKey, String accountNo, String authCode) {
+        String apiName = "checkAuthCode";
+        RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
+        CheckAuthCodeRequest request = CheckAuthCodeRequest.of(header, accountNo, appName, authCode);
+        return webClientHelper.postRequest(url + "/api/v1/edu/accountAuth/checkAuthCode", request, CheckAuthCodeResponse.class);
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/dto/CheckAuthCodeRequest.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/dto/CheckAuthCodeRequest.java
@@ -1,0 +1,27 @@
+package com.alddeul.solsolhanhankki.account.auth.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CheckAuthCodeRequest {
+    @JsonProperty("Header")
+    private RequestHeader header;
+    private String accountNo;
+    private String authText;
+    private String authCode;
+
+    public static CheckAuthCodeRequest of(RequestHeader header, String accountNo, String authText, String authCode) {
+        return CheckAuthCodeRequest.builder()
+                .header(header)
+                .accountNo(accountNo)
+                .authText(authText)
+                .authCode(authCode)
+                .build();
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/dto/CheckAuthCodeResponse.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/dto/CheckAuthCodeResponse.java
@@ -1,0 +1,24 @@
+package com.alddeul.solsolhanhankki.account.auth.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckAuthCodeResponse {
+    @JsonProperty("Header")
+    private RequestHeader header;
+    @JsonProperty("REC")
+    private Rec rec;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Rec {
+        private String status;
+        private Long transactionUniqueNo;
+        private String accountNo;
+
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/dto/OneCentTransferRequest.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/dto/OneCentTransferRequest.java
@@ -1,0 +1,26 @@
+package com.alddeul.solsolhanhankki.account.auth.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OneCentTransferRequest {
+    @JsonProperty("Header")
+    private RequestHeader header;
+    private String accountNo;
+    private String authText;
+
+    public static OneCentTransferRequest of(RequestHeader header, String accountNo, String authText) {
+        return OneCentTransferRequest.builder()
+                .header(header)
+                .accountNo(accountNo)
+                .authText(authText)
+                .build();
+
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/dto/OneCentTransferResponse.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/dto/OneCentTransferResponse.java
@@ -1,0 +1,23 @@
+package com.alddeul.solsolhanhankki.account.auth.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.ResponseHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+public class OneCentTransferResponse {
+    @JsonProperty("Header")
+    private ResponseHeader header;
+    @JsonProperty("REC")
+    private Rec rec;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Rec {
+        private Long transactionUniqueNo;
+        private String accountNo;
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/AccountClient.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/AccountClient.java
@@ -1,0 +1,46 @@
+package com.alddeul.solsolhanhankki.account.deposit.client;
+
+import com.alddeul.solsolhanhankki.account.deposit.client.dto.*;
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.alddeul.solsolhanhankki.global.client.util.WebClientHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class AccountClient {
+    private final WebClientHelper webClientHelper;
+
+    @Value("${financial.api.base-url}")
+    private String url;
+
+    @Value("${financial.api.key}")
+    private String appKey;
+
+    @Value("${financial.api.default.account-type}")
+    private String defaultAccountType;
+
+
+    public CreateAccountResponse createDemandDepositAccount(String userKey) {
+        String apiName = "createDemandDepositAccount";
+        RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
+        CreateAccountRequest request = CreateAccountRequest.of(header, defaultAccountType);
+        return webClientHelper.postRequest(url + "/api/v1/edu/demandDeposit/createDemandDepositAccount", request, CreateAccountResponse.class);
+    }
+
+    public InquireAccountListResponse inquireDemandDepositAccountList(String userKey) {
+        String apiName = "inquireDemandDepositAccountList";
+        RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
+        InquireAccountListRequest request = InquireAccountListRequest.of(header);
+        return webClientHelper.postRequest(url + "/api/v1/edu/demandDeposit/inquireDemandDepositAccountList", request, InquireAccountListResponse.class);
+    }
+
+    public InquireAccountHistoryResponse inquireTransactionHistory(String userKey, String accountNo, Long transactionNo) {
+        String apiName = "inquireTransactionHistory";
+        RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
+        InquireAccountHistoryRequest request = InquireAccountHistoryRequest.of(header, accountNo, transactionNo);
+        return webClientHelper.postRequest(url + "/api/v1/edu/demandDeposit/inquireTransactionHistory", request, InquireAccountHistoryResponse.class);
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/CreateAccountRequest.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/CreateAccountRequest.java
@@ -1,0 +1,23 @@
+package com.alddeul.solsolhanhankki.account.deposit.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CreateAccountRequest {
+    @JsonProperty("Header")
+    private RequestHeader header;
+    private String accountTypeUniqueNo;
+
+    public static CreateAccountRequest of(RequestHeader header, String accountTypeUniqueNo) {
+        return CreateAccountRequest.builder()
+                .header(header)
+                .accountTypeUniqueNo(accountTypeUniqueNo)
+                .build();
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/CreateAccountResponse.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/CreateAccountResponse.java
@@ -1,0 +1,33 @@
+package com.alddeul.solsolhanhankki.account.deposit.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.ResponseHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Currency;
+
+@Getter
+@NoArgsConstructor
+public class CreateAccountResponse {
+    @JsonProperty("Header")
+    private ResponseHeader header;
+    @JsonProperty("REC")
+    private Rec rec;
+    private Currency currency;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Rec {
+        private String bankCode;
+        private String accountNo;
+        private Currency currency;
+
+        @Getter
+        @NoArgsConstructor
+        public static class Currency {
+            private String currency;
+            private String currencyName;
+        }
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/InquireAccountHistoryRequest.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/InquireAccountHistoryRequest.java
@@ -1,0 +1,25 @@
+package com.alddeul.solsolhanhankki.account.deposit.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class InquireAccountHistoryRequest {
+    @JsonProperty("Header")
+    private RequestHeader header;
+    private String accountNo;
+    private Long transactionUniqueNo;
+
+    public static InquireAccountHistoryRequest of(RequestHeader header, String accountNo, Long transactionUniqueNo) {
+        return InquireAccountHistoryRequest.builder()
+                .header(header)
+                .accountNo(accountNo)
+                .transactionUniqueNo(transactionUniqueNo)
+                .build();
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/InquireAccountHistoryResponse.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/InquireAccountHistoryResponse.java
@@ -1,0 +1,28 @@
+package com.alddeul.solsolhanhankki.account.deposit.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InquireAccountHistoryResponse {
+    @JsonProperty("Header")
+    private RequestHeader header;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Rec {
+        private Long transactionUniqueNo;
+        private String transactionDate;
+        private String transactionTime;
+        private String transactionType;
+        private String transactionTypeName;
+        private String transactionAccountNo;
+        private Long transactionBalance;
+        private Long transactionAfterBalance;
+        private String transactionSummary;
+        private String transactionMemo;
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/InquireAccountListRequest.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/InquireAccountListRequest.java
@@ -1,0 +1,19 @@
+package com.alddeul.solsolhanhankki.account.deposit.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class InquireAccountListRequest {
+    @JsonProperty("Header")
+    private RequestHeader header;
+
+    public static InquireAccountListRequest of(RequestHeader header) {
+        return InquireAccountListRequest.builder().header(header).build();
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/InquireAccountListResponse.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/dto/InquireAccountListResponse.java
@@ -1,0 +1,36 @@
+package com.alddeul.solsolhanhankki.account.deposit.client.dto;
+
+import com.alddeul.solsolhanhankki.global.client.dto.ResponseHeader;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class InquireAccountListResponse {
+    @JsonProperty("Header")
+    private ResponseHeader header;
+    @JsonProperty("REC")
+    private List<Rec> rec;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Rec {
+        private String bankCode;
+        private String bankName;
+        private String userName;
+        private String accountNo;
+        private String accountName;
+        private String accountTypeCode;
+        private String accountTypeName;
+        private String accountCreatedDate;
+        private String accountExpiryDate;
+        private String dailyTransferLimit;
+        private String oneTimeTransferLimit;
+        private String accountBalance;
+        private String lastTransactionDate;
+        private String current;
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/global/client/dto/RequestHeader.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/global/client/dto/RequestHeader.java
@@ -1,0 +1,51 @@
+package com.alddeul.solsolhanhankki.global.client.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class RequestHeader {
+    private String apiName;
+    private String transmissionDate;
+    private String transmissionTime;
+    private String institutionCode;
+    private String fintechAppNo;
+    private String apiServiceCode;
+    private String institutionTransactionUniqueNo;
+    private String apiKey;
+    private String userKey;
+
+    private static final String DEFAULT_INSTITUTION_CODE = "00100";
+    private static final String DEFAULT_FINTECH_APP_NO = "001";
+
+    public static RequestHeader of(String apiName, String apiKey, String userKey) {
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String time = LocalTime.now().format(DateTimeFormatter.ofPattern("HHmmss"));
+        String uniqueNo = generateUniqueNo(date, time);
+
+        return RequestHeader.builder()
+                .apiName(apiName)
+                .transmissionDate(date)
+                .transmissionTime(time)
+                .institutionCode(DEFAULT_INSTITUTION_CODE)
+                .fintechAppNo(DEFAULT_FINTECH_APP_NO)
+                .apiServiceCode(apiName)
+                .institutionTransactionUniqueNo(uniqueNo)
+                .apiKey(apiKey)
+                .userKey(userKey)
+                .build();
+    }
+
+    private static String generateUniqueNo(String date, String time) {
+        int random = ThreadLocalRandom.current().nextInt(100000, 1000000);
+        return date + time + random;
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/global/client/dto/ResponseHeader.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/global/client/dto/ResponseHeader.java
@@ -1,0 +1,18 @@
+package com.alddeul.solsolhanhankki.global.client.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ResponseHeader {
+    private String responseCode;
+    private String responseMessage;
+    private String apiName;
+    private String transmissionDate;
+    private String transmissionTime;
+    private String institutionCode;
+    private String apiKey;
+    private String apiServiceCode;
+    private String institutionTransactionUniqueNo;
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/global/client/util/WebClientHelper.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/global/client/util/WebClientHelper.java
@@ -1,0 +1,42 @@
+package com.alddeul.solsolhanhankki.global.client.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebClientHelper {
+    private final WebClient webClient;
+
+    public <T> T postRequest(String uri, Object body, Class<T> responseType) {
+        try {
+            return webClient.post()
+                    .uri(uri)
+                    .bodyValue(body)
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                            this::handleErrorResponse)
+                    .bodyToMono(responseType)
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.error("HTTP 상태 코드: {}, 응답 본문: {}", e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("API 호출 실패", e);
+        }
+    }
+
+    private Mono<Throwable> handleErrorResponse(ClientResponse clientResponse) {
+        return clientResponse.bodyToMono(String.class)
+                .flatMap(errorBody -> {
+                    log.error("API 오류 응답: {}", errorBody);
+                    return Mono.error(new RuntimeException("API 호출 실패: " + errorBody));
+                });
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/global/config/WebClientConfig.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/global/config/WebClientConfig.java
@@ -1,0 +1,42 @@
+package com.alddeul.solsolhanhankki.global.config;
+
+
+import io.netty.channel.ChannelOption;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
+
+import java.time.Duration;
+
+@Configuration
+public class WebClientConfig {
+    private static final Integer DEFAULT_TIMEOUT = 1000 * 20;
+    private static final Integer DEFAULT_MEMORY_SIZE = 2 * 1024 * 1024;
+    HttpClient httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, DEFAULT_TIMEOUT);
+
+    @Bean
+    public WebClient webClient(){
+        return WebClient.builder()
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .codecs(config -> config.defaultCodecs().maxInMemorySize(DEFAULT_MEMORY_SIZE))
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+
+    @Bean
+    public ConnectionProvider connectionProvider() {
+        //데이터가 전달되기 전 커넥션 끊김 방지
+        return ConnectionProvider.builder("http-pool")
+                .maxConnections(100)
+                .pendingAcquireTimeout(Duration.ofMillis(0))
+                .pendingAcquireMaxCount(-1)
+                .maxIdleTime(Duration.ofMillis(1000L))
+                .build();
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/user/client/UserClient.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/user/client/UserClient.java
@@ -1,0 +1,30 @@
+package com.alddeul.solsolhanhankki.user.client;
+
+import com.alddeul.solsolhanhankki.global.client.util.WebClientHelper;
+import com.alddeul.solsolhanhankki.user.client.dto.UserRequest;
+import com.alddeul.solsolhanhankki.user.client.dto.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserClient {
+    private final WebClientHelper webClientHelper;
+
+    @Value("${financial.api.base-url}")
+    private String url;
+
+    @Value("${financial.api.key}")
+    private String appKey;
+
+    public UserResponse loginUser(String email) {
+        UserRequest request = UserRequest.of(appKey, email);
+        return webClientHelper.postRequest(url + "/api/v1/member", request, UserResponse.class);
+    }
+
+    public UserResponse searchUser(String email) {
+        UserRequest request = UserRequest.of(appKey, email);
+        return webClientHelper.postRequest(url + "/api/v1/member/search", request, UserResponse.class);
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserRequest.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserRequest.java
@@ -1,0 +1,20 @@
+package com.alddeul.solsolhanhankki.user.client.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserRequest {
+    private String apiKey;
+    private String userId;
+
+    public static UserRequest of(String apiKey, String userId) {
+        return UserRequest.builder()
+                .apiKey(apiKey)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserResponse.java
+++ b/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserResponse.java
@@ -1,0 +1,17 @@
+package com.alddeul.solsolhanhankki.user.client.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@NoArgsConstructor
+public class UserResponse {
+    private String userId;
+    private String userName;
+    private String institutionCode;
+    private String userKey;
+    private OffsetDateTime  created;
+    private OffsetDateTime modified;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,11 @@ logging:
   level:
     root: INFO
     org.springframework.web: INFO
+
+financial:
+  api:
+    base-url: ${FINANCIAL_BASE_URL}
+    key: ${FINANCIAL_API_KEY}
+    name: 쏠쏠한한끼
+    default:
+      account-type: ${FINANCIAL_DEFAULT_ACCOUNT_TYPE}


### PR DESCRIPTION
## 개요
- SSAFY 금융망에 사용자 앱 등록, 지갑형 간편 결제에 계좌 등록을 구현하기 위한 SSAFY 금융API 호출부 코드를 작성한다.

## 변경 사항
- 사용자 회원가입
- 계좌 등록
- 계좌 조회
- 거래내역 조회
- 1원 송금 / 검증
API 스펙에 맞춰 webclient 코드를 작성한다.

## 관련 이슈
- resolves #3 
