### PR TITLE
[AH-16] SSAFY 금융앱 등록

### DIFF
--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/AccountAuthClient.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/account/auth/client/AccountAuthClient.java
@@ -4,6 +4,7 @@ import com.alddeul.solsolhanhankki.account.auth.client.dto.CheckAuthCodeRequest;
 import com.alddeul.solsolhanhankki.account.auth.client.dto.CheckAuthCodeResponse;
 import com.alddeul.solsolhanhankki.account.auth.client.dto.OneCentTransferRequest;
 import com.alddeul.solsolhanhankki.account.auth.client.dto.OneCentTransferResponse;
+import com.alddeul.solsolhanhankki.global.client.dto.ApiResponse;
 import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
 import com.alddeul.solsolhanhankki.global.client.util.WebClientHelper;
 import lombok.RequiredArgsConstructor;
@@ -24,14 +25,14 @@ public class AccountAuthClient {
     @Value("${financial.api.name}")
     private String appName;
 
-    public OneCentTransferResponse openAccountAuth(String userKey, String accountNo) {
+    public ApiResponse<OneCentTransferResponse> openAccountAuth(String userKey, String accountNo) {
         String apiName = "openAccountAuth";
         RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
         OneCentTransferRequest request = OneCentTransferRequest.of(header, accountNo, appName);
         return webClientHelper.postRequest(url + "/api/v1/edu/accountAuth/openAccountAuth", request, OneCentTransferResponse.class);
     }
 
-    public CheckAuthCodeResponse checkAuthCode(String userKey, String accountNo, String authCode) {
+    public ApiResponse<CheckAuthCodeResponse> checkAuthCode(String userKey, String accountNo, String authCode) {
         String apiName = "checkAuthCode";
         RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
         CheckAuthCodeRequest request = CheckAuthCodeRequest.of(header, accountNo, appName, authCode);

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/AccountClient.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/account/deposit/client/AccountClient.java
@@ -1,6 +1,7 @@
 package com.alddeul.solsolhanhankki.account.deposit.client;
 
 import com.alddeul.solsolhanhankki.account.deposit.client.dto.*;
+import com.alddeul.solsolhanhankki.global.client.dto.ApiResponse;
 import com.alddeul.solsolhanhankki.global.client.dto.RequestHeader;
 import com.alddeul.solsolhanhankki.global.client.util.WebClientHelper;
 import lombok.RequiredArgsConstructor;
@@ -23,21 +24,21 @@ public class AccountClient {
     private String defaultAccountType;
 
 
-    public CreateAccountResponse createDemandDepositAccount(String userKey) {
+    public ApiResponse<CreateAccountResponse> createDemandDepositAccount(String userKey) {
         String apiName = "createDemandDepositAccount";
         RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
         CreateAccountRequest request = CreateAccountRequest.of(header, defaultAccountType);
         return webClientHelper.postRequest(url + "/api/v1/edu/demandDeposit/createDemandDepositAccount", request, CreateAccountResponse.class);
     }
 
-    public InquireAccountListResponse inquireDemandDepositAccountList(String userKey) {
+    public ApiResponse<InquireAccountListResponse> inquireDemandDepositAccountList(String userKey) {
         String apiName = "inquireDemandDepositAccountList";
         RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
         InquireAccountListRequest request = InquireAccountListRequest.of(header);
         return webClientHelper.postRequest(url + "/api/v1/edu/demandDeposit/inquireDemandDepositAccountList", request, InquireAccountListResponse.class);
     }
 
-    public InquireAccountHistoryResponse inquireTransactionHistory(String userKey, String accountNo, Long transactionNo) {
+    public ApiResponse<InquireAccountHistoryResponse> inquireTransactionHistory(String userKey, String accountNo, Long transactionNo) {
         String apiName = "inquireTransactionHistory";
         RequestHeader header = RequestHeader.of(apiName, appKey, userKey);
         InquireAccountHistoryRequest request = InquireAccountHistoryRequest.of(header, accountNo, transactionNo);

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/global/client/dto/ApiResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/global/client/dto/ApiResponse.java
@@ -1,0 +1,12 @@
+package com.alddeul.solsolhanhankki.global.client.dto;
+
+public record ApiResponse<T>(boolean success, T data, ErrorResponse error) {
+
+    public static <T> ApiResponse<T> ofData(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> ofError(ErrorResponse error) {
+        return new ApiResponse<>(false,null, error);
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/global/client/dto/ErrorResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/global/client/dto/ErrorResponse.java
@@ -1,0 +1,6 @@
+package com.alddeul.solsolhanhankki.global.client.dto;
+
+public record ErrorResponse(
+        String responseCode,
+        String responseMessage
+) {}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/application/UserAccountService.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/application/UserAccountService.java
@@ -1,0 +1,41 @@
+package com.alddeul.solsolhanhankki.user.application;
+
+import com.alddeul.solsolhanhankki.global.client.dto.ApiResponse;
+import com.alddeul.solsolhanhankki.user.client.UserClient;
+import com.alddeul.solsolhanhankki.user.client.dto.UserApiResponse;
+import com.alddeul.solsolhanhankki.user.presentation.request.UserRequest;
+import com.alddeul.solsolhanhankki.user.presentation.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserAccountService {
+    private final UserService userService;
+    private final UserClient userClient;
+
+    public UserResponse createUser(UserRequest userRequest) {
+        String email = userRequest.email();
+
+        // 1. 사용자 검색
+        ApiResponse<UserApiResponse> searchResponse = userClient.searchUser(email);
+        if (searchResponse.success()) {
+            return UserResponse.of(UserResponse.Status.ALREADY_REGISTERED);
+        }
+
+        // 2. 앱 등록하지 않은 사용자 → 등록 시도
+        if ("E4003".equals(searchResponse.error().responseCode())) {
+            ApiResponse<UserApiResponse> loginResponse = userClient.loginUser(email);
+            if (loginResponse.success()) {
+                userService.registerUserAtBank(email, loginResponse.data().userKey());
+                return UserResponse.of(UserResponse.Status.REGISTERED);
+            }
+            return UserResponse.of(UserResponse.Status.REGISTRATION_FAILED, loginResponse.error().responseMessage());
+        }
+
+        // 3. 기타 실패
+        return UserResponse.of(UserResponse.Status.REGISTRATION_FAILED, searchResponse.error().responseMessage());
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/application/UserService.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/application/UserService.java
@@ -1,0 +1,20 @@
+package com.alddeul.solsolhanhankki.user.application;
+
+import com.alddeul.solsolhanhankki.user.model.entity.SolUser;
+import com.alddeul.solsolhanhankki.user.model.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerUserAtBank(String email, String userKey) {
+        SolUser user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        user.registerUserAtBank(userKey);
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/UserClient.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/UserClient.java
@@ -1,8 +1,8 @@
 package com.alddeul.solsolhanhankki.user.client;
 
 import com.alddeul.solsolhanhankki.global.client.util.WebClientHelper;
-import com.alddeul.solsolhanhankki.user.client.dto.UserRequest;
-import com.alddeul.solsolhanhankki.user.client.dto.UserResponse;
+import com.alddeul.solsolhanhankki.user.client.dto.UserApiRequest;
+import com.alddeul.solsolhanhankki.user.client.dto.UserApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -18,13 +18,13 @@ public class UserClient {
     @Value("${financial.api.key}")
     private String appKey;
 
-    public UserResponse loginUser(String email) {
-        UserRequest request = UserRequest.of(appKey, email);
-        return webClientHelper.postRequest(url + "/api/v1/member", request, UserResponse.class);
+    public UserApiResponse loginUser(String email) {
+        UserApiRequest request = UserApiRequest.of(appKey, email);
+        return webClientHelper.postRequest(url + "/api/v1/member", request, UserApiResponse.class);
     }
 
-    public UserResponse searchUser(String email) {
-        UserRequest request = UserRequest.of(appKey, email);
-        return webClientHelper.postRequest(url + "/api/v1/member/search", request, UserResponse.class);
+    public UserApiResponse searchUser(String email) {
+        UserApiRequest request = UserApiRequest.of(appKey, email);
+        return webClientHelper.postRequest(url + "/api/v1/member/search", request, UserApiResponse.class);
     }
 }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/UserClient.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/UserClient.java
@@ -1,5 +1,6 @@
 package com.alddeul.solsolhanhankki.user.client;
 
+import com.alddeul.solsolhanhankki.global.client.dto.ApiResponse;
 import com.alddeul.solsolhanhankki.global.client.util.WebClientHelper;
 import com.alddeul.solsolhanhankki.user.client.dto.UserApiRequest;
 import com.alddeul.solsolhanhankki.user.client.dto.UserApiResponse;
@@ -18,12 +19,12 @@ public class UserClient {
     @Value("${financial.api.key}")
     private String appKey;
 
-    public UserApiResponse loginUser(String email) {
+    public ApiResponse<UserApiResponse> loginUser(String email) {
         UserApiRequest request = UserApiRequest.of(appKey, email);
         return webClientHelper.postRequest(url + "/api/v1/member", request, UserApiResponse.class);
     }
 
-    public UserApiResponse searchUser(String email) {
+    public ApiResponse<UserApiResponse> searchUser(String email) {
         UserApiRequest request = UserApiRequest.of(appKey, email);
         return webClientHelper.postRequest(url + "/api/v1/member/search", request, UserApiResponse.class);
     }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserApiRequest.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserApiRequest.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class UserRequest {
+public class UserApiRequest {
     private String apiKey;
     private String userId;
 
-    public static UserRequest of(String apiKey, String userId) {
-        return UserRequest.builder()
+    public static UserApiRequest of(String apiKey, String userId) {
+        return UserApiRequest.builder()
                 .apiKey(apiKey)
                 .userId(userId)
                 .build();

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserApiResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserApiResponse.java
@@ -7,7 +7,7 @@ import java.time.OffsetDateTime;
 
 @Getter
 @NoArgsConstructor
-public class UserResponse {
+public class UserApiResponse {
     private String userId;
     private String userName;
     private String institutionCode;

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserApiResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/client/dto/UserApiResponse.java
@@ -1,17 +1,13 @@
 package com.alddeul.solsolhanhankki.user.client.dto;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
 
-@Getter
-@NoArgsConstructor
-public class UserApiResponse {
-    private String userId;
-    private String userName;
-    private String institutionCode;
-    private String userKey;
-    private OffsetDateTime  created;
-    private OffsetDateTime modified;
-}
+public record UserApiResponse (
+    String userId,
+    String userName,
+    String institutionCode,
+    String userKey,
+    OffsetDateTime created,
+    OffsetDateTime modified
+){}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/model/entity/SolUser.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/model/entity/SolUser.java
@@ -22,4 +22,17 @@ public class SolUser extends BaseIdentityEntity {
 
     @Column(length = 50)
     private String major;
+
+    @Column(nullable = false)
+    private String email;
+
+    private String accessKey;
+
+
+    public void registerUserAtBank(String accessKey) {
+        if (accessKey != null) {
+            throw new IllegalStateException("이미 은행에 등록된 사용자입니다.");
+        }
+        this.accessKey = accessKey;
+    }
 }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/model/repository/UserRepository.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/model/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.alddeul.solsolhanhankki.user.model.repository;
+
+
+import com.alddeul.solsolhanhankki.user.model.entity.SolUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<SolUser, Long> {
+    Optional<SolUser> findByEmail(String email);
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/presentation/UserController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/presentation/UserController.java
@@ -1,0 +1,24 @@
+package com.alddeul.solsolhanhankki.user.presentation;
+
+import com.alddeul.solsolhanhankki.user.application.UserAccountService;
+import com.alddeul.solsolhanhankki.user.presentation.request.UserRequest;
+import com.alddeul.solsolhanhankki.user.presentation.response.UserResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+    private final UserAccountService userAccountService;
+
+    @PostMapping()
+    public ResponseEntity<UserResponse> createUser(@RequestBody UserRequest userRequest) {
+        var response = userAccountService.createUser(userRequest);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/presentation/request/UserRequest.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/presentation/request/UserRequest.java
@@ -1,0 +1,5 @@
+package com.alddeul.solsolhanhankki.user.presentation.request;
+
+public record UserRequest(
+        String email
+) {}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/presentation/response/UserResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/user/presentation/response/UserResponse.java
@@ -1,0 +1,21 @@
+package com.alddeul.solsolhanhankki.user.presentation.response;
+
+public record UserResponse(
+        Status status,
+        String message
+
+) {
+    public static UserResponse of(Status status, String message) {
+        return new UserResponse(status, message);
+    }
+
+    public static UserResponse of(Status status) {
+        return new UserResponse(status, null);
+    }
+
+    public enum Status {
+        REGISTRATION_FAILED,
+        REGISTERED,
+        ALREADY_REGISTERED,
+    }
+}


### PR DESCRIPTION
## 개요
- 금융 API 이용을 위한 등록 및 확인 기능

## 변경 사항
- [핵심 변경 1] 앱에서 사용자 검색 후 존재하지 않는 사용자면 등록, 반환받은 userKey를 저장하도록 구현
- [핵심 변경 2] 외부 API 요청시 오류 결과도 반환받기 위해, 공통 `ApiResponse` 제네릭 클래스로 리팩토링
- sol_user 엔티티에 email, accessKey 필드 추가
---
- 1원 송금과 검증 과정은 구현하지 못했습니다. 변경 내용이 많아질 것 같아 우선 작은 단위로 PR 올렸습니다
- 테스트를 위해 `test1@email.com` 이메일 사용자를 이용할 수 있습니다.
- 사용자가 이미 헤이영을 이용하고 있다고 가정하여, user insert 로직은 구현하지 않았습니다.
- DTO는 일부 record로 변환중에 있습니다.

## 관련 이슈
- resolves #14 
