### PR TITLE
[AH-11] outbox 패턴 도입

### DIFF
--- a/solsolhanhankki/.gitignore
+++ b/solsolhanhankki/.gitignore
@@ -49,6 +49,10 @@ replay_pid*
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
+.gradle/
+.metadata/
+.settings/
+
 
 ## NetBeans
 /nbproject/private/

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/outbox/model/entity/OutboxEvent.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/outbox/model/entity/OutboxEvent.java
@@ -1,0 +1,45 @@
+package com.alddeul.solsolhanhankki.outbox.model.entity;
+
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import com.alddeul.solsolhanhankki.common.jpa.base.entity.BaseIdentityEntity;
+import com.alddeul.solsolhanhankki.common.jpa.base.entity.BaseTimeEntity;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "outbox_event")
+@Builder
+@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OutboxEvent extends BaseIdentityEntity {  
+    @Column(nullable = false, length = 100)
+    private String aggregateType;
+
+    @Column(nullable = false)
+    private Long aggregateId;
+
+    @Column(nullable = false, length = 100)
+    private String eventType;
+
+    @Column(nullable = false)
+    private boolean processed;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private JsonNode payload;
+
+    public void updateProcessed(boolean status) {
+        this.processed = status;
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/outbox/repository/OutboxEventRepository.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/outbox/repository/OutboxEventRepository.java
@@ -1,0 +1,11 @@
+package com.alddeul.solsolhanhankki.outbox.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.alddeul.solsolhanhankki.outbox.model.entity.OutboxEvent;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+    List<OutboxEvent> findByProcessedFalse();
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/outbox/service/OutboxProcessor.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/outbox/service/OutboxProcessor.java
@@ -1,0 +1,43 @@
+package com.alddeul.solsolhanhankki.outbox.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.alddeul.solsolhanhankki.outbox.model.entity.OutboxEvent;
+import com.alddeul.solsolhanhankki.outbox.repository.OutboxEventRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OutboxProcessor {
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    @Transactional
+    public void processUnsentEvents() {
+        List<OutboxEvent> events = outboxEventRepository.findByProcessedFalse();
+
+        for (OutboxEvent event : events) {
+            try {
+                sendEvent(event);
+
+                // 성공 시 processed = true 업데이트
+                event.updateProcessed(true);
+                outboxEventRepository.save(event);
+
+            } catch (Exception e) {
+                // 실패하면 롤백 → processed=false 유지 → 다음 배치에서 재시도
+                throw new RuntimeException("이벤트 처리 실패", e);
+            }
+        }
+    }
+
+    private void sendEvent(OutboxEvent event) {
+       log.info("발행: {} payload : {}", event.getEventType(), event.getPayload());
+    }
+}


### PR DESCRIPTION
## 개요
- 비동기적으로 동작할 푸쉬 알림, 그룹 방 상태의 데이터 정합성을 보장 하기 위해 outbox 패턴을 도입

## 변경 사항
- outbox entity, repository생성
- processor를 만들어 한 곳에서 처리하도록 함

## 관련 이슈
- resolves #8 
