### PR TITLE
[AH-37] Controller url 수정

### DIFF
--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/controller/FcmTokenController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/controller/FcmTokenController.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/api/fcm")
+@RequestMapping("/sol/api/fcm")
 @CrossOrigin(origins = {"http://localhost:4173"})
 public class FcmTokenController {
 	private final FcmTokenService fcmTokenService;

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/controller/TestNotificationController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/controller/TestNotificationController.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/test")
+@RequestMapping("/sol/api/test")
 @RequiredArgsConstructor
 public class TestNotificationController {
 


### PR DESCRIPTION
## 개요
- nginx 서버 구분을 위해 controller mapping url을 수정해야합니다.

## 변경 사항
- FCM 관련 controller의 url을 수정했습니다.

## 관련 이슈
- resolves #38 
