### PR TITLE
[AH-38] 캠퍼스의 Group을 조회하는 API 구현

### DIFF
--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/campus/model/repository/PickupZoneRepository.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/campus/model/repository/PickupZoneRepository.java
@@ -4,6 +4,9 @@ import com.alddeul.solsolhanhankki.campus.model.entity.PickupZone;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PickupZoneRepository extends JpaRepository<PickupZone, Long> {
+    List<PickupZone> findByCampus_Id(Long campusId);
 }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/campus/presentation/CampusController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/campus/presentation/CampusController.java
@@ -1,0 +1,33 @@
+package com.alddeul.solsolhanhankki.campus.presentation;
+
+import com.alddeul.solsolhanhankki.campus.model.entity.PickupZone;
+import com.alddeul.solsolhanhankki.campus.model.repository.PickupZoneRepository;
+import com.alddeul.solsolhanhankki.campus.presentation.response.PickupZoneResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/sol/api/campus")
+@RequiredArgsConstructor
+public class CampusController {
+
+    private final PickupZoneRepository pickupZoneRepository;
+
+    @GetMapping("/{campusId}/pickup-zones")
+    public ResponseEntity<List<PickupZoneResponse>> getPickupZonesByCampus(@PathVariable Long campusId) {
+        List<PickupZone> pickupZones = pickupZoneRepository.findByCampus_Id(campusId);
+
+        List<PickupZoneResponse> responses = pickupZones.stream()
+                .map(PickupZoneResponse::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/campus/presentation/response/PickupZoneResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/campus/presentation/response/PickupZoneResponse.java
@@ -1,0 +1,26 @@
+package com.alddeul.solsolhanhankki.campus.presentation.response;
+
+import com.alddeul.solsolhanhankki.campus.model.entity.PickupZone;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+public record PickupZoneResponse(
+        Long id,
+        String name,
+        String description,
+        BigDecimal latitude,
+        BigDecimal longitude
+
+) {
+    public static PickupZoneResponse from(PickupZone pickupZone) {
+        return PickupZoneResponse.builder()
+                .id(pickupZone.getId())
+                .name(pickupZone.getName())
+                .latitude(pickupZone.getLatitude())
+                .longitude(pickupZone.getLongitude())
+                .description(pickupZone.getDescription())
+                .build();
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/application/GroupService.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/application/GroupService.java
@@ -1,0 +1,30 @@
+package com.alddeul.solsolhanhankki.order.application;
+
+import com.alddeul.solsolhanhankki.order.model.entity.Groups;
+import com.alddeul.solsolhanhankki.order.model.enums.GroupStatus;
+import com.alddeul.solsolhanhankki.order.model.repository.GroupRepository;
+import com.alddeul.solsolhanhankki.order.presentation.response.GroupSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupService {
+
+    private final GroupRepository groupRepository;
+
+    public List<GroupSummaryResponse> getRecruitingGroups(Long campusId) {
+        List<GroupStatus> statuses = List.of(GroupStatus.RECRUITING, GroupStatus.TRIGGERED);
+
+        List<Groups> availableGroups = groupRepository.findAllByStatusInAndPickupZone_Campus_Id(statuses, campusId);
+
+        return availableGroups.stream()
+                .map(GroupSummaryResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/application/OrderService.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/application/OrderService.java
@@ -83,6 +83,10 @@ public class OrderService {
                 .orElseThrow(() -> new EntityNotFoundException("그룹을 찾을 수 없습니다. ID: " + calcResult.group.getId()));
         lockedGroup.addParticipant(calcResult.menuTotalPrice);
 
+        if (lockedGroup.getStatus() == GroupStatus.RECRUITING && lockedGroup.isTriggered()) {
+            lockedGroup.trigger(); // 상태를 TRIGGERED로 바꾸고 deadlineAt을 5분 뒤로 변경
+        }
+
         PaymentRequest paymentRequest = PaymentRequest.of(
                 order,
                 request.storeName(),

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/entity/Groups.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/entity/Groups.java
@@ -30,6 +30,12 @@ public class Groups extends BaseIdentityEntity {
     private GroupStatus status = GroupStatus.RECRUITING;
 
     @Column(nullable = false)
+    private OffsetDateTime scheduledDeadlineAt;
+
+    @Column(nullable = false)
+    private OffsetDateTime scheduledPickupAt;
+
+    @Column(nullable = false)
     private String storeId;
 
     @Column(nullable = false)
@@ -70,6 +76,8 @@ public class Groups extends BaseIdentityEntity {
         this.minOrderPrice = minOrderPrice;
         this.deliveryFeePolicies = deliveryFeePolicies;
         this.triggerPrice = triggerPrice;
+        this.scheduledDeadlineAt = scheduledDeadlineAt;
+        this.scheduledPickupAt = scheduledPickupAt;
         this.deadlineAt = deadlineAt;
         this.pickupAt = pickupAt;
     }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/entity/Groups.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/entity/Groups.java
@@ -126,11 +126,6 @@ public class Groups extends BaseIdentityEntity {
         this.participantCount++;
     }
 
-    public void trigger() {
-        this.status = GroupStatus.TRIGGERED;
-        this.triggeredAt = OffsetDateTime.now();
-    }
-
     public void removeParticipant(Long menuTotalPrice) {
         this.currentTotalPrice -= menuTotalPrice;
         this.participantCount--;
@@ -153,5 +148,15 @@ public class Groups extends BaseIdentityEntity {
 
     public void cancel() {
         this.status = GroupStatus.CANCELED;
+    }
+
+    public boolean isTriggered() {
+        return this.currentTotalPrice >= this.triggerPrice;
+    }
+
+    public void trigger() {
+        this.status = GroupStatus.TRIGGERED;
+        this.triggeredAt = OffsetDateTime.now(); // 트리거된 시간 기록
+        this.deadlineAt = OffsetDateTime.now().plusMinutes(5); // 마감 시간을 '지금으로부터 5분 뒤'로 변경
     }
 }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/repository/GroupRepository.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/repository/GroupRepository.java
@@ -25,4 +25,7 @@ public interface GroupRepository extends JpaRepository<Groups, Long> {
     Optional<Groups> findAvailableGroupBy(String storeId, Long pickupZoneId, OffsetDateTime deadlineAt);
 
     List<Groups> findAllByStatusAndTriggeredAtBefore(GroupStatus status, OffsetDateTime threshold);
+
+    List<Groups> findAllByStatusInAndPickupZone_Campus_Id(List<GroupStatus> statuses, Long campusId);
+
 }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/GroupController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/GroupController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/groups")
+@RequestMapping("/sol/api/groups")
 @RequiredArgsConstructor
 public class GroupController {
 

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/GroupController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/GroupController.java
@@ -5,7 +5,7 @@ import com.alddeul.solsolhanhankki.order.presentation.request.GroupSummaryReques
 import com.alddeul.solsolhanhankki.order.presentation.response.GroupSummaryResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,7 +19,7 @@ public class GroupController {
 
     private final GroupService groupService;
 
-    @GetMapping
+    @PostMapping
     public ResponseEntity<List<GroupSummaryResponse>> getGroups(
             @RequestBody GroupSummaryRequest  groupSummaryRequest
             ) {

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/GroupController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/GroupController.java
@@ -1,0 +1,29 @@
+package com.alddeul.solsolhanhankki.order.presentation;
+
+import com.alddeul.solsolhanhankki.order.application.GroupService;
+import com.alddeul.solsolhanhankki.order.presentation.request.GroupSummaryRequest;
+import com.alddeul.solsolhanhankki.order.presentation.response.GroupSummaryResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/groups")
+@RequiredArgsConstructor
+public class GroupController {
+
+    private final GroupService groupService;
+
+    @GetMapping
+    public ResponseEntity<List<GroupSummaryResponse>> getGroups(
+            @RequestBody GroupSummaryRequest  groupSummaryRequest
+            ) {
+        List<GroupSummaryResponse> groups = groupService.getRecruitingGroups(groupSummaryRequest.campusId());
+        return ResponseEntity.ok(groups);
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/OrderController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/OrderController.java
@@ -34,7 +34,7 @@ public class OrderController {
     @PostMapping
     public ResponseEntity<OrderConfirmationResponse> createOrder(@RequestBody OrderRequest orderRequest) {
         OrderConfirmationResponse response = orderService.createOrder(orderRequest);
-        return ResponseEntity.created(URI.create("/api/orders/" + response.getOrderId())).body(response);
+        return ResponseEntity.created(URI.create("/api/orders/" + response.orderId())).body(response);
     }
 
     @PostMapping("/cancel")

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/request/GroupSummaryRequest.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/request/GroupSummaryRequest.java
@@ -1,0 +1,6 @@
+package com.alddeul.solsolhanhankki.order.presentation.request;
+
+public record GroupSummaryRequest(
+        Long campusId
+) {
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/GroupSummaryResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/GroupSummaryResponse.java
@@ -7,11 +7,15 @@ import java.time.OffsetDateTime;
 public record GroupSummaryResponse(
         Long groupId,
         String storeName,
+        String storeId,
+        String imageUrl,
         String pickupZoneName,
         OffsetDateTime deadlineAt,
         Integer participantCount,
         Long currentTotalPrice,
-        Long amountToTarget
+        Long amountToTarget,
+        OffsetDateTime scheduledDeadlineAt,
+        OffsetDateTime scheduledPickupAt
 ) {
 
     public static GroupSummaryResponse from(Groups group) {
@@ -20,11 +24,15 @@ public record GroupSummaryResponse(
         return new GroupSummaryResponse(
                 group.getId(),
                 group.getStoreName(),
+                group.getStoreId(),
+                "https://dwdwaxgahvp6i.cloudfront.net/shbimg/biz/img/2022/10/c69204e3-2145-48db-82cb-6f1867666e78.jpg",
                 group.getPickupZone().getName(),
                 group.getDeadlineAt(),
                 group.getParticipantCount(),
                 group.getCurrentTotalPrice(),
-                amountToTarget
+                amountToTarget,
+                group.getScheduledDeadlineAt(),
+                group.getScheduledPickupAt()
         );
     }
 }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/GroupSummaryResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/GroupSummaryResponse.java
@@ -1,0 +1,30 @@
+package com.alddeul.solsolhanhankki.order.presentation.response;
+
+import com.alddeul.solsolhanhankki.order.model.entity.Groups;
+
+import java.time.OffsetDateTime;
+
+public record GroupSummaryResponse(
+        Long groupId,
+        String storeName,
+        String pickupZoneName,
+        OffsetDateTime deadlineAt,
+        Integer participantCount,
+        Long currentTotalPrice,
+        Long amountToTarget
+) {
+
+    public static GroupSummaryResponse from(Groups group) {
+        long amountToTarget = Math.max(0, group.getTriggerPrice() - group.getCurrentTotalPrice());
+
+        return new GroupSummaryResponse(
+                group.getId(),
+                group.getStoreName(),
+                group.getPickupZone().getName(),
+                group.getDeadlineAt(),
+                group.getParticipantCount(),
+                group.getCurrentTotalPrice(),
+                amountToTarget
+        );
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/OrderConfirmationResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/OrderConfirmationResponse.java
@@ -2,14 +2,14 @@ package com.alddeul.solsolhanhankki.order.presentation.response;
 
 import com.alddeul.solsolhanhankki.order.model.entity.Orders;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class OrderConfirmationResponse {
-    private Long orderId;
-    private String storeName;
-    private Long paymentAmount;
+public record OrderConfirmationResponse(
+        Long orderId,
+        String storeName,
+        Long paymentAmount
+) {
+
 
     public static OrderConfirmationResponse from(Orders order) {
         return OrderConfirmationResponse.builder()

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/OrderItemResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/OrderItemResponse.java
@@ -2,15 +2,15 @@ package com.alddeul.solsolhanhankki.order.presentation.response;
 
 import com.alddeul.solsolhanhankki.order.presentation.request.OrderItemRequest;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class OrderItemResponse {
-    private String menuName;
-    private Integer quantity;
-    private Long pricePerItem;
-    private String options;
+public record OrderItemResponse(
+        String menuName,
+        Integer quantity,
+        Long pricePerItem,
+        String options
+) {
+
 
     public static OrderItemResponse from(OrderItemRequest item) {
         return OrderItemResponse.builder()

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/OrderPreviewResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/response/OrderPreviewResponse.java
@@ -1,18 +1,19 @@
 package com.alddeul.solsolhanhankki.order.presentation.response;
 
 import lombok.Builder;
-import lombok.Getter;
 
 import java.util.List;
 
 // '주문 확인 페이지' UI에 필요한 모든 정보를 담는 DTO
-@Getter
+
 @Builder
-public class OrderPreviewResponse {
-    private String storeName;
-    private List<OrderItemResponse> orderItems;
-    private Long menuTotalPrice;
-    private Long originalDeliveryFee;
-    private Long expectedDiscountedDeliveryFee;
-    private Long paymentAmount;
+public record OrderPreviewResponse(
+        String storeName,
+        List<OrderItemResponse> orderItems,
+        Long menuTotalPrice,
+        Long originalDeliveryFee,
+        Long expectedDiscountedDeliveryFee,
+        Long paymentAmount
+) {
+
 }


### PR DESCRIPTION
## 개요
- 캠퍼스에 존재하는 모든 Group을 조회하는 API 를 구현하였습니다.

## 변경 사항
- `/sol/api/groups`
  - 해당 엔드포인트는 캠퍼스에 존재하는 모든 group을 반환합니다.

## 관련 이슈
- resolves #44 
