### PR TITLE
feat: accountNo request에서 제거

### DIFF
--- a/heyyoung/src/main/java/com/alddeul/heyyoung/domain/account/model/repository/AccountRepository.java
+++ b/heyyoung/src/main/java/com/alddeul/heyyoung/domain/account/model/repository/AccountRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, Long> {
     List<Account> findByAccountNumberIn(List<String> accountNumbers);
+
+    Optional<Account> findBySolUser_Email(String email);
 }

--- a/heyyoung/src/main/java/com/alddeul/heyyoung/domain/paymoney/application/PayMoneyService.java
+++ b/heyyoung/src/main/java/com/alddeul/heyyoung/domain/paymoney/application/PayMoneyService.java
@@ -7,6 +7,8 @@ import com.alddeul.heyyoung.common.outbox.repository.OutboxRepository;
 import com.alddeul.heyyoung.domain.account.external.deposit.FinanceAccountClient;
 import com.alddeul.heyyoung.domain.account.external.deposit.dto.DepositAccountResponse;
 import com.alddeul.heyyoung.domain.account.external.deposit.dto.WithdrawalAccountResponse;
+import com.alddeul.heyyoung.domain.account.model.entity.Account;
+import com.alddeul.heyyoung.domain.account.model.repository.AccountRepository;
 import com.alddeul.heyyoung.domain.paymoney.model.entity.PayMoney;
 import com.alddeul.heyyoung.domain.paymoney.model.entity.RefundIntent;
 import com.alddeul.heyyoung.domain.paymoney.model.entity.TopUpIntent;
@@ -40,6 +42,7 @@ public class PayMoneyService {
     private final OutboxRepository outboxRepository;
     private final TopUpIntentRepository topUpIntentRepository;
     private final RefundIntentRepository refundIntentRepository;
+    private final AccountRepository accountRepository;
     private final UserRepository userRepository;
     private final UserFacade userFacade;
 
@@ -85,7 +88,9 @@ public class PayMoneyService {
         final String email = payMoneyTransactionRequest.email();
 
         final String userKey = userFacade.getUserKey(email);
-        final String accountNo = payMoneyTransactionRequest.accountNo();
+        final String accountNo = accountRepository.findBySolUser_Email(email)
+                .map(Account::getAccountNumber)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 계좌가 없습니다."));
         final Long amount = payMoneyTransactionRequest.transactionBalance();
         final String summary = payMoneyTransactionRequest.transactionSummary().isEmpty()
                 ? "PayMoney 충전"
@@ -112,7 +117,9 @@ public class PayMoneyService {
         final String email = payMoneyTransactionRequest.email();
 
         final String userKey = userFacade.getUserKey(email);
-        final String accountNo = payMoneyTransactionRequest.accountNo();
+        final String accountNo = accountRepository.findBySolUser_Email(email)
+                .map(Account::getAccountNumber)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이메일의 계좌가 없습니다."));
         final Long amount = payMoneyTransactionRequest.transactionBalance();
         final String summary = payMoneyTransactionRequest.transactionSummary().isEmpty()
                 ? "PayMoney 환불"

--- a/heyyoung/src/main/java/com/alddeul/heyyoung/domain/paymoney/presentation/request/PayMoneyInquiryRequest.java
+++ b/heyyoung/src/main/java/com/alddeul/heyyoung/domain/paymoney/presentation/request/PayMoneyInquiryRequest.java
@@ -1,8 +1,7 @@
 package com.alddeul.heyyoung.domain.paymoney.presentation.request;
 
 public record PayMoneyInquiryRequest(
-        String email,
-        String accountNo
+        String email
 ) {
 
 }

--- a/heyyoung/src/main/java/com/alddeul/heyyoung/domain/paymoney/presentation/request/PayMoneyTransactionRequest.java
+++ b/heyyoung/src/main/java/com/alddeul/heyyoung/domain/paymoney/presentation/request/PayMoneyTransactionRequest.java
@@ -2,7 +2,6 @@ package com.alddeul.heyyoung.domain.paymoney.presentation.request;
 
 public record PayMoneyTransactionRequest(
         String email,
-        String accountNo,
         Long transactionBalance,
         String transactionSummary
 ) {


### PR DESCRIPTION
## 개요
- 유저가 accountNo를 알 수 없어서, accountNo를 entity에서 가져오도록 하였습니다.

## 변경 사항
- 충전, 환불 로직의 accountNo를 입력받는 부분을 제거했습니다.

## 관련 이슈
- resolves #47 
