### PR TITLE
[AH-43] AI 서버측 클러스터링을 위한 유저 분석 API 구현

### DIFF
--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/analytics/application/UserAnalyticsService.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/analytics/application/UserAnalyticsService.java
@@ -1,0 +1,70 @@
+package com.alddeul.solsolhanhankki.analytics.application;
+
+import com.alddeul.solsolhanhankki.analytics.presentation.response.UserPreferenceResponse;
+import com.alddeul.solsolhanhankki.order.model.entity.OrderItems;
+import com.alddeul.solsolhanhankki.order.model.entity.Orders;
+import com.alddeul.solsolhanhankki.order.model.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserAnalyticsService {
+
+    private final OrderRepository orderRepository;
+
+    // AI 서버가 요구하는 전체 카테고리 목록 (변경 가능)
+    private static final Set<String> ALL_CATEGORIES = Set.of("치킨", "피자", "한식");
+
+    @Transactional(readOnly = true)
+    public List<UserPreferenceResponse> getCategoryPreferences(List<Long> userIds) {
+        return userIds.stream()
+                .map(this::calculateSingleUserPreferences)
+                .collect(Collectors.toList());
+    }
+
+    private UserPreferenceResponse calculateSingleUserPreferences(Long userId) {
+        List<Orders> recentOrders = orderRepository.findByUserIdOrderByCreatedAtDesc(userId, PageRequest.of(0, 20));
+
+        Map<String, Integer> categoryCounts = new HashMap<>();
+        long totalCategoryCount = 0;
+
+        for (Orders order : recentOrders) {
+            if (order.getOrderItems() != null) {
+                for (OrderItems item : order.getOrderItems()) {
+                    if (item.getCategory() != null) {
+                        for (String category : item.getCategory()) {
+                            categoryCounts.put(category, categoryCounts.getOrDefault(category, 0) + 1);
+                            totalCategoryCount++;
+                        }
+                    }
+                }
+            }
+        }
+
+        // 전체 카테고리 목록으로 맵을 초기화하고, 기본 가중치를 0.0으로 설정합니다.
+        Map<String, Double> preferences = new HashMap<>();
+        for (String category : ALL_CATEGORIES) {
+            preferences.put(category, 0.0);
+        }
+
+        // 계산된 가중치를 덮어씌웁니다.
+        if (totalCategoryCount > 0) {
+            for (Map.Entry<String, Integer> entry : categoryCounts.entrySet()) {
+                double weight = (double) entry.getValue() / totalCategoryCount;
+                preferences.put(entry.getKey(), weight);
+            }
+        }
+
+        return new UserPreferenceResponse(userId, preferences);
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/analytics/presentation/AnalyticsController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/analytics/presentation/AnalyticsController.java
@@ -1,0 +1,28 @@
+// solsolhanhankki/analytics/presentation/AnalyticsController.java
+package com.alddeul.solsolhanhankki.analytics.presentation;
+
+import com.alddeul.solsolhanhankki.analytics.application.UserAnalyticsService;
+import com.alddeul.solsolhanhankki.analytics.presentation.request.UserPreferencesRequest;
+import com.alddeul.solsolhanhankki.analytics.presentation.response.UserPreferenceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/sol/api/analytics")
+@RequiredArgsConstructor
+public class AnalyticsController {
+
+    private final UserAnalyticsService userAnalyticsService;
+
+    @PostMapping("/user-preferences")
+    public ResponseEntity<List<UserPreferenceResponse>> getUserCategoryPreferences(@RequestBody UserPreferencesRequest request) {
+        List<UserPreferenceResponse> response = userAnalyticsService.getCategoryPreferences(request.userIds());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/analytics/presentation/request/UserPreferencesRequest.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/analytics/presentation/request/UserPreferencesRequest.java
@@ -1,0 +1,7 @@
+package com.alddeul.solsolhanhankki.analytics.presentation.request;
+
+import java.util.List;
+
+public record UserPreferencesRequest(
+        List<Long> userIds
+) {}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/analytics/presentation/response/UserPreferenceResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/analytics/presentation/response/UserPreferenceResponse.java
@@ -1,0 +1,9 @@
+package com.alddeul.solsolhanhankki.analytics.presentation.response;
+
+import java.util.Map;
+
+public record UserPreferenceResponse(
+        Long userId,
+        Map<String, Double> preferences
+) {
+}

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/entity/OrderItems.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/entity/OrderItems.java
@@ -39,6 +39,11 @@ public class OrderItems extends BaseIdentityEntity {
     @Column(nullable = false)
     private Integer quantity = 1;
 
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(name = "order_item_categories", joinColumns = @JoinColumn(name = "order_item_id"))
+    @Column(name = "category")
+    private List<String> category;
+
     @Builder
     public OrderItems(Orders order, String menuId, String menuName, String options, Long pricePerItem, Integer quantity) {
         this.order = order;

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/repository/OrderRepository.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/model/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.alddeul.solsolhanhankki.order.model.repository;
 
 import com.alddeul.solsolhanhankki.order.model.entity.Orders;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -18,4 +19,5 @@ public interface OrderRepository extends JpaRepository<Orders, Long> {
 
     Optional<Orders> findByPaymentToken(String paymentToken);
 
+    List<Orders> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/request/OrderItemRequest.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/request/OrderItemRequest.java
@@ -1,9 +1,12 @@
 package com.alddeul.solsolhanhankki.order.presentation.request;
 
+import java.util.List;
+
 public record OrderItemRequest(
         String menuId,
         String menuName,
         String options,
         Long pricePerItem,
-        Integer quantity
+        Integer quantity,
+        List<String> category
 ) {}


### PR DESCRIPTION
## 개요
- 각 사용자의 주문기록을 토대로 선호 카테고리를 분석하여 제공하는 API 구현

## 변경 사항
- `/analytics/user-preferences`
  - 각 User의 최근 주문 20건을 토대로, 주문한 음식의 카테고리 비중을 조사하여 List로 반환합니다.

## 관련 이슈
- resolves #52 
