### PR TITLE
[AH-44] 주문 관련 알림 서비스 구현

### DIFF
--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/campus/presentation/response/PickupZoneResponse.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/campus/presentation/response/PickupZoneResponse.java
@@ -1,9 +1,10 @@
 package com.alddeul.solsolhanhankki.campus.presentation.response;
 
-import com.alddeul.solsolhanhankki.campus.model.entity.PickupZone;
-import lombok.Builder;
-
 import java.math.BigDecimal;
+
+import com.alddeul.solsolhanhankki.campus.model.entity.PickupZone;
+
+import lombok.Builder;
 
 @Builder
 public record PickupZoneResponse(

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/controller/TestNotificationController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/controller/TestNotificationController.java
@@ -24,28 +24,26 @@ public class TestNotificationController {
     private final NotificationService notificationService;
     private final OutboxProcessor outboxProcessor;
 
-    @GetMapping("/notification")
-    public String testNotification(@RequestParam(name="userId", defaultValue = "1") long userId) {
-        try {
-            // 테스트 알림 이벤트 생성
-            NotificationEventDto notification = new NotificationEventDto(
-                userId,
-                "테스트 알림",
-                "테스트 알립입니다!",
-                "/solsol",
-                NotificationEventType.FCM_NOTIFICATION_SEND,
-                OffsetDateTime.now()
-            );
-            
-            notificationService.sendNotificationToUser(notification);
-            
-            log.info("테스트 알림 이벤트 생성 완료: userId={}", userId);
-            return "테스트 알림 이벤트가 생성되었습니다. Outbox 처리를 기다리세요.";
-            
-        } catch (Exception e) {
-            log.error("테스트 알림 생성 실패: {}", e.getMessage());
-            return "테스트 알림 생성 실패: " + e.getMessage();
-        }
+    @GetMapping("/notification/order-success")
+    public String testOrderSuccess(@RequestParam("groupId") long groupId) {
+    	try {
+    		notificationService.createNotificationOrderSuccess(groupId);
+    		return "주문 확정 알림 이벤트가 생성되었습니다.";
+    	} catch (Exception e) {
+    		log.error("주문 확정 알림 생성 실패: {}", e.getMessage());
+    		return "생성 실패: " + e.getMessage();
+    	}
+    }
+
+    @GetMapping("/notification/order-fail")
+    public String testOrderFail(@RequestParam("groupId") long groupId) {
+    	try {
+    		notificationService.createNotificationOrderFail(groupId);
+    		return "주문 실패 알림 이벤트가 생성되었습니다.";
+    	} catch (Exception e) {
+    		log.error("주문 실패 알림 생성 실패: {}", e.getMessage());
+    		return "생성 실패: " + e.getMessage();
+    	}
     }
 
     @GetMapping("/outbox/process")

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/repository/FcmTokenRepository.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/repository/FcmTokenRepository.java
@@ -9,7 +9,8 @@ import java.util.Optional;
 
 @Repository
 public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
-    Optional<FcmToken> findByToken(String token);
-    List<FcmToken> findByUserId(long userId);
-    void deleteByToken(String token);
+	Optional<FcmToken> findByToken(String token);
+	List<FcmToken> findByUserId(long userId);
+	List<FcmToken> findByUserIdIn(List<Long> userIds);
+	void deleteByToken(String token);
 }

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/service/NotificationService.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/notification/service/NotificationService.java
@@ -1,18 +1,23 @@
 package com.alddeul.solsolhanhankki.notification.service;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
 
 import com.alddeul.solsolhanhankki.notification.domain.FcmToken;
+import com.alddeul.solsolhanhankki.notification.domain.NotificationEventType;
 import com.alddeul.solsolhanhankki.notification.dto.NotificationEventDto;
 import com.alddeul.solsolhanhankki.notification.repository.FcmTokenRepository;
+import com.alddeul.solsolhanhankki.order.model.entity.Orders;
+import com.alddeul.solsolhanhankki.order.model.repository.OrderRepository;
 import com.alddeul.solsolhanhankki.outbox.domain.OutboxEvent;
 import com.alddeul.solsolhanhankki.outbox.repository.OutboxEventRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,7 +28,9 @@ public class NotificationService {
 	private final FcmTokenRepository fcmTokenRepository;
 	private final OutboxEventRepository outboxEventRepository;
 	private final ObjectMapper mapper;
+	private final OrderRepository orderRepository;
 	
+	@Transactional
 	public void sendNotificationToUser(NotificationEventDto notification) {
 		try {
 			List<FcmToken> tokens = fcmTokenRepository.findByUserId(notification.userId());
@@ -37,11 +44,83 @@ public class NotificationService {
 		}
 	}
 	
+	@Transactional
+	public void createNotificationOrderSuccess(long groupId) {
+		try {
+			List<Orders> orders = orderRepository.findAllByGroupId(groupId);
+
+			for (Orders order : orders) {
+				long userId = order.getUserId();
+				String storeName = order.getGroup().getStoreName();
+				String title = storeName + " 주문이 확정되었어요";
+				String body = "픽업 시간: " + order.getGroup().getPickupAt();
+				String url = "/solsol";
+
+				NotificationEventDto notification = new NotificationEventDto(
+					userId, title, body, url,
+					NotificationEventType.FCM_NOTIFICATION_SEND, OffsetDateTime.now()
+				);
+
+				sendNotificationToUser(notification);
+			}
+		} catch (Exception e) {
+			log.info("주문 확정 알림 생성 실패 {}", e.getMessage());
+		}
+	}
+
+	// 실패 알림만 새 트랜잭션으로 저장 (fully-qualified 사용으로 import 최소화)
+	@org.springframework.transaction.annotation.Transactional(
+		propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW
+	)
+	public void createNotificationOrderFail(long groupId) {
+		try {
+			List<Orders> orders = orderRepository.findAllByGroupId(groupId);
+
+			for (Orders order : orders) {
+				long userId = order.getUserId();
+				String storeName = order.getGroup().getStoreName();
+				String title = storeName + " 주문이 실패했어요";
+				String body = "주문이 목표 금액에 도달 하지 못했어요.";
+				String url = "/solsol";
+
+				NotificationEventDto notification = new NotificationEventDto(
+					userId, title, body, url,
+					NotificationEventType.FCM_NOTIFICATION_SEND, OffsetDateTime.now()
+				);
+
+				sendNotificationToUser(notification);
+			}
+		} catch (Exception e) {
+			log.info("주문 실패 알림 생성 실패 {}", e.getMessage());
+		}
+	}
+	
+	@Transactional
+	public void createRecommendNotification(List<Long> userIds, String storeName) {
+		try {
+			String title = "같이 주문하는 건 어떠신가요?";
+			String body = storeName + " 에서 같이 주문을 해보세요!";
+			String url = "/solsol";
+			
+			for(Long userId : userIds) {
+				NotificationEventDto notification = new NotificationEventDto(
+						userId, title, body, url,
+						NotificationEventType.FCM_NOTIFICATION_SEND, OffsetDateTime.now()
+					);
+
+				sendNotificationToUser(notification);
+			}
+		}catch(Exception e) {
+			log.info("추천 알림 생성 실패 {}", e.getMessage());
+		}
+	}
+	
 	private void createNotificationOutboxEvent(String token, NotificationEventDto notification) {
 		Map<String, Object> payloadMap = Map.of(
 				"token", token,
 				"title", notification.title(),
 				"body", notification.body(),
+				"url", notification.url(),
 				"userId", notification.userId(),
 				"timestamp", System.currentTimeMillis()
 				);

--- a/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/OrderController.java
+++ b/solsolhanhankki/src/main/java/com/alddeul/solsolhanhankki/order/presentation/OrderController.java
@@ -1,19 +1,27 @@
 package com.alddeul.solsolhanhankki.order.presentation;
 
+import java.io.IOException;
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.alddeul.solsolhanhankki.notification.service.NotificationService;
 import com.alddeul.solsolhanhankki.order.application.OrderService;
 import com.alddeul.solsolhanhankki.order.presentation.request.CancelRequest;
 import com.alddeul.solsolhanhankki.order.presentation.request.OrderPreviewRequest;
 import com.alddeul.solsolhanhankki.order.presentation.request.OrderRequest;
 import com.alddeul.solsolhanhankki.order.presentation.response.OrderConfirmationResponse;
 import com.alddeul.solsolhanhankki.order.presentation.response.OrderPreviewResponse;
+
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.io.IOException;
-import java.net.URI;
 
 @RestController
 @RequestMapping("/sol/api/orders")
@@ -21,7 +29,7 @@ import java.net.URI;
 public class OrderController {
 
     private final OrderService orderService;
-
+    
     @Value("${solsol.client.url}")
     private String clientAppUrl;
 

--- a/solsolhanhankki/src/main/resources/application-prod.yml
+++ b/solsolhanhankki/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
     show-sql: false
 
 firebase:
@@ -25,3 +25,7 @@ payment:
     url: ${PROD_PAYMENT_API_URL}
   callback:
     url: ${PROD_PAYMENT_CALLBACK_URL}
+
+solsol:
+  client:
+    url: ${SOLSOL_CLIENT_URL}


### PR DESCRIPTION
## 개요
- 주문 성공, 실패, 추천 알림을 위해 service 구현

## 변경 사항
- 그룹 id 에 포함된 유저에게 주문 성공 알림을 구현 했습니다.
- 그룹 id 에 포함된 유저에게 주문 실패 알림을 구현 했습니다.
- AI 클러스터링의 같은 군집 user에게 보낼 알림을 구현 했습니다.
- test 코드를 변경했습니다.

## 관련 이슈
- resolves #53 
